### PR TITLE
non-32-bit constant non-symbolic function pointers on x86_64

### DIFF
--- a/x86_64-gen.c
+++ b/x86_64-gen.c
@@ -600,7 +600,7 @@ static void gcall_or_jmp(int is_jmp)
 {
     int r;
     if ((vtop->r & (VT_VALMASK | VT_LVAL)) == VT_CONST &&
-	vtop->c.ll == (int)vtop->c.ll) {
+	(vtop->c.ll-4) == (int)(vtop->c.ll-4)) {
         /* constant case */
         if (vtop->r & VT_SYM) {
             /* relocation case */

--- a/x86_64-gen.c
+++ b/x86_64-gen.c
@@ -600,7 +600,7 @@ static void gcall_or_jmp(int is_jmp)
 {
     int r;
     if ((vtop->r & (VT_VALMASK | VT_LVAL)) == VT_CONST &&
-	(vtop->c.ll-4) == (int)(vtop->c.ll-4)) {
+	((vtop->r & VT_SYM) || (vtop->c.ll-4) == (int)(vtop->c.ll-4))) {
         /* constant case */
         if (vtop->r & VT_SYM) {
             /* relocation case */

--- a/x86_64-gen.c
+++ b/x86_64-gen.c
@@ -599,7 +599,8 @@ void store(int r, SValue *v)
 static void gcall_or_jmp(int is_jmp)
 {
     int r;
-    if ((vtop->r & (VT_VALMASK | VT_LVAL)) == VT_CONST) {
+    if ((vtop->r & (VT_VALMASK | VT_LVAL)) == VT_CONST &&
+	vtop->c.ll == (int)vtop->c.ll) {
         /* constant case */
         if (vtop->r & VT_SYM) {
             /* relocation case */


### PR DESCRIPTION
Hi,
I don't know whether you're interested in pull requests for tinycc. Sorry if you're not.

This is a fairly obvious bug fix for calling a non-32-bit constant non-symbolic function pointer on x86_64. I'm using tinycc as a miniature JIT compiler and was using decimal constants for other symbols rather than going through the symbol definition mechanism, which shouldn't be faster than doing it the right way, but should still work.

It's hard to come up with a test case because that would rely on knowing the address of a non-32-bit symbol, but do let me know if you absolutely require one and I'll see what I can do.

Philip
